### PR TITLE
[Refactor] Reworking the Contract Class

### DIFF
--- a/e2e/test_get_code.py
+++ b/e2e/test_get_code.py
@@ -4,11 +4,6 @@ import unittest
 from src.fetch.contracts import EvmAccountInfo
 from src.files import NetworkFile
 
-NODE_URL = {
-    'mainnet': os.environ.get('NODE_URL'),
-    'gchain': 'https://rpc.gnosischain.com/',
-}
-
 test_file = NetworkFile(name="test-file.csv", path='./out/test')
 
 
@@ -53,12 +48,12 @@ class TestCodeGetter(unittest.TestCase):
             network='mainnet'
         )
         with self.assertRaises(RuntimeError):
-            contract_detector._limited_is_contract(self.addresses)
+            contract_detector._get_code_at(self.addresses)
 
         contract_detector.max_batch_size = len(self.addresses)
 
         self.assertEqual(
-            contract_detector._limited_is_contract(self.addresses),
+            contract_detector._get_code_at(self.addresses),
             self.expected
         )
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -11,6 +11,11 @@ SNAPSHOT_BLOCK_NUMBER = {
     'gchain': os.environ.get('SNAPSHOT_BLOCK_XDAI', "20024195"),
 }
 
+NODE_URL = {
+    'mainnet': os.environ.get('NODE_URL'),
+    'gchain': 'https://rpc.gnosischain.com/',
+}
+
 FILE_OUT_PATH = os.environ.get('FILE_OUT_PATH', './out')
 
 # Lowest total balance of GNO to be considered eligible for allocation

--- a/src/fetch/contracts.py
+++ b/src/fetch/contracts.py
@@ -3,7 +3,6 @@ Single use EthRPC module for fetching code at address specified
 and determining whether the address is a deployed smart contract.
 """
 import argparse
-from collections import defaultdict
 
 import requests
 

--- a/src/fetch/contracts.py
+++ b/src/fetch/contracts.py
@@ -3,6 +3,7 @@ Single use EthRPC module for fetching code at address specified
 and determining whether the address is a deployed smart contract.
 """
 import argparse
+from typing import Callable
 
 import requests
 
@@ -74,7 +75,11 @@ class EvmAccountInfo:
             contracts = set(txt_file.read().splitlines())
         return {addr: addr in contracts for addr in self.addresses}
 
-    def batch_call(self, addresses: list[str], func):
+    def batch_call(
+            self,
+            addresses: list[str],
+            func: Callable[[list[str]], dict[str, int | str]]
+    ) -> dict[str, int | str]:
         print(f"making batch call for {len(addresses)} addresses on "
               f"{self.network} (this will take a while)...")
         results = {}

--- a/src/fetch/contracts.py
+++ b/src/fetch/contracts.py
@@ -3,7 +3,7 @@ Single use EthRPC module for fetching code at address specified
 and determining whether the address is a deployed smart contract.
 """
 import argparse
-from typing import Callable
+from typing import Callable, TypeVar
 
 import requests
 
@@ -11,6 +11,9 @@ from src.files import NetworkFile
 from src.models import Account
 from src.utils.data import File
 from src.utils.file import write_to_csv
+
+# pylint: disable=invalid-name
+V = TypeVar('V', int, str)
 
 
 # pylint: disable=too-few-public-methods
@@ -78,8 +81,8 @@ class EvmAccountInfo:
     def batch_call(
             self,
             addresses: list[str],
-            func: Callable[[list[str]], dict[str, int | str]]
-    ) -> dict[str, int | str]:
+            func: Callable[[list[str]], dict[str, V]]
+    ) -> dict[str, V]:
         print(f"making batch call for {len(addresses)} addresses on "
               f"{self.network} (this will take a while)...")
         results = {}

--- a/src/fetch/contracts.py
+++ b/src/fetch/contracts.py
@@ -3,16 +3,17 @@ Single use EthRPC module for fetching code at address specified
 and determining whether the address is a deployed smart contract.
 """
 import argparse
+from collections import defaultdict
 
 import requests
 
-# pylint: disable=too-few-public-methods
 from src.files import NetworkFile
 from src.models import Account
 from src.utils.data import File
 from src.utils.file import write_to_csv
 
 
+# pylint: disable=too-few-public-methods
 class EvmAccountInfo:
     """
     Class consisting of 3 parameters to determine if the addresses are contracts.
@@ -34,19 +35,12 @@ class EvmAccountInfo:
         # de-duplicate to reduce unnecessary queries
         self.addresses = list(set(addresses))
         self.null_balance_file = NetworkFile("null-balances.csv")
+        # TODO - could store the results of batch calls in the instance
+        #  However this would require self.update_all whenever the addresses change.
 
-    def _limited_is_contract(self, addresses: list[str]) -> dict[str, bool]:
+    def _get_code_at(self, addresses: list[str]) -> dict[str, str]:
         """
-        :return: map {address => is_contract}
-        Example:
-        [
-            '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
-            '0xa4A6A282A7fC7F939e01D62D884355d79f5046C1',
-        ] ->
-        {
-            '0x9008D19f58AAbD9eD0D60971565AA8510560ab41': True,
-            '0xa4A6A282A7fC7F939e01D62D884355d79f5046C1': False,
-        }
+        :return: map {address => byte_code_at_address}
         """
         if len(addresses) > self.max_batch_size:
             size = len(addresses)
@@ -66,20 +60,29 @@ class EvmAccountInfo:
         results = {}
         for result_dict in response.json():
             try:
-                results[addresses[result_dict['id']]] = result_dict['result'] != "0x"
+                results[addresses[result_dict['id']]] = result_dict['result']
             except KeyError as err:
                 raise IOError(
-                    f"Request for address \"{addresses[result_dict['id']]}\" "
+                    f"Request for code at address \"{addresses[result_dict['id']]}\" "
                     f"failed with response {result_dict}"
                 ) from err
         return results
 
     def load_from_file(self, file: File) -> dict[str, bool]:
         """Loads results dict from a file containing known contract addresses"""
-        print(f"Loading Contracts from {file.name}")
+        print(f"loading contracts from {file.name}")
         with open(file.filename(), 'r', encoding='utf-8') as txt_file:
             contracts = set(txt_file.read().splitlines())
         return {addr: addr in contracts for addr in self.addresses}
+
+    def batch_call(self, addresses: list[str], func):
+        print(f"making batch call for {len(addresses)} addresses on "
+              f"{self.network} (this will take a while)...")
+        results = {}
+        for index in range(0, len(addresses), self.max_batch_size):
+            partition = addresses[index:index + self.max_batch_size]
+            results |= func(partition)
+        return results
 
     def contracts(self, load_from: NetworkFile) -> dict[str, bool]:
         """
@@ -93,15 +96,14 @@ class EvmAccountInfo:
             except FileNotFoundError:
                 print(f"file at {load_from.name} not found. Fetching from Node")
 
-        addresses = self.addresses
-        print(f"Fetching code at {len(addresses)} addresses on "
-              f"{self.network} (this will take a while)...")
-        results = {}
-        for index in range(0, len(addresses), self.max_batch_size):
-            partition = addresses[index:index + self.max_batch_size]
-            results |= self._limited_is_contract(partition)
-
-        confirmed_contracts = sorted([Account(k) for k, v in results.items() if v])
+        batch_results = self.batch_call(self.addresses, self._get_code_at)
+        results = {
+            account: code != "0x"
+            for account, code in batch_results.items()
+        }
+        confirmed_contracts = sorted(
+            [Account(k) for k, v in results.items() if v]
+        )
         print(f"found {len(confirmed_contracts)} contracts, writing to file")
         write_to_csv(data_list=confirmed_contracts, outfile=load_file)
         return results
@@ -129,12 +131,7 @@ class EvmAccountInfo:
         return results
 
     def get_null_balances(self, epsilon=10 ** 16) -> set[str]:
-        print(f"Fetching balances at {len(self.addresses)} addresses on "
-              f"{self.network} (this may take a while)...")
-        results = {}
-        for index in range(0, len(self.addresses), self.max_batch_size):
-            partition = self.addresses[index:index + self.max_batch_size]
-            results |= self._limited_balances(partition)
+        results = self.batch_call(self.addresses, self._limited_balances)
 
         null_balances = sorted([Account(k) for k, v in results.items() if v < epsilon])
         print(f"found {len(null_balances)} accounts will zero balance, writing to file")

--- a/src/generate/merkle_data.py
+++ b/src/generate/merkle_data.py
@@ -119,7 +119,7 @@ class MerkleLeaf:
         )
 
     def __str__(self):
-        return f"{self.Account}: {self.Airdrop / 10 ** 18}"
+        return f"{self.Account} - {self.Airdrop / 10 ** 18}"
 
     def __hash__(self):
         return self.Account.__hash__()


### PR DESCRIPTION
In preparation for fetching contract allocations, we need to rework the contract class to be more adapted for making batch calls and fetching bytecode. This just makes the next PR more clean. Although it might be a good place to do an even better job refactoring this class (for example we never actually use the boolean mapping returned by the is_contract method). 

Required to merge before #9