### PR TITLE
Write Misallocations to File

### DIFF
--- a/src/scripts/contract_allocations.py
+++ b/src/scripts/contract_allocations.py
@@ -2,6 +2,7 @@ from src.constants import NODE_URL
 from src.fetch.contracts import EvmAccountInfo
 from src.files import AllocationFiles, NetworkFile, File
 from src.generate.merkle_data import MerkleLeaf
+from src.utils.file import write_to_csv
 
 
 def non_wallet_allocation(network: str, allocation_file: File) -> int:
@@ -20,10 +21,11 @@ def non_wallet_allocation(network: str, allocation_file: File) -> int:
     sorted_contract_allocations = sorted([
         a for a in allocations if a.Account in contracts
     ], key=lambda t: t.Airdrop, reverse=True)
-
+    misallocations = []
     airdrop_total, found = 0, 0
     for alloc in sorted_contract_allocations:
         if alloc.Account in not_wallets:
+            misallocations.append(alloc)
             # proof that this only affects GNO allocations!
             gno_allocation = alloc.Airdrop + alloc.GnoOption
             assert alloc.total() - gno_allocation == 0
@@ -33,7 +35,7 @@ def non_wallet_allocation(network: str, allocation_file: File) -> int:
                 print(
                     f"{found}. {alloc.Account} - {(alloc.Airdrop / 1e24):.3f}M"
                 )
-
+    write_to_csv(misallocations, File(f"{network}-misallocations.csv"))
     print(f"total {network} (in WEI) {airdrop_total}")
     return airdrop_total
 


### PR DESCRIPTION
These two Dune Queries show the total amount of claimed vCOW in WEI representing the exact amount of COW that  should be deposited into the vCOW token contract for claiming:

https://dune.xyz/queries/536342
https://dune.xyz/queries/536337

The lists for exclusion (found in the linked queries) are generated here by the code introduced in this PR.

To generate the list yourself run

```sh
python -m src.scripts.contract_allocations
```

Have attached them here for convenience

[mainnet-misallocations.csv](https://github.com/gnosis/cow-token-allocation/files/8350302/mainnet-misallocations.csv)

[gchain-misallocations.csv](https://github.com/gnosis/cow-token-allocation/files/8350305/gchain-misallocations.csv)



Note also, at this moment, only one of the misallocated claims have been made (although quite large):


Someone ([this account](https://blockscout.com/xdai/mainnet/address/0x64BeE0A4729A616146Ec945560DdFaf15C08f661/transactions)) claimed on behalf of the [StakeGNOMerge contract](https://blockscout.com/xdai/mainnet/address/0x918a1f8eE8F8f9E0802071929ce5fe9EfF60aC8C/transactions) at this transaction
https://blockscout.com/xdai/mainnet/tx/0xd3fce359babfac4e7e333e33ba992ab2e2f881b715848c10aad562d956a968d8

